### PR TITLE
Max Width on Pin Cards

### DIFF
--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -4,4 +4,5 @@ body {
 
 .pin-card {
   height: fit-content;
+  max-width: 300px;
 }


### PR DESCRIPTION
## Description

Added a maximum width to pin cards.

## Motivation and Context

Keeps pin cards from getting too big.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
